### PR TITLE
fix: Fixed default typings on the Semaphore.

### DIFF
--- a/src/Mutex.ts
+++ b/src/Mutex.ts
@@ -1,19 +1,19 @@
 import MutexInterface from './MutexInterface';
 import Semaphore, { QueueEntry, QueueLike } from './Semaphore';
 
-class Mutex implements MutexInterface {
-    constructor(cancelError?: Error, queue?: QueueLike<QueueEntry>) {
-        this._semaphore = new Semaphore(1, cancelError, queue);
+class Mutex<U = void> implements MutexInterface<U> {
+    constructor(cancelError?: Error, queue?: QueueLike<QueueEntry<U>>) {
+        this._semaphore = new Semaphore<U>(1, cancelError, queue);
     }
 
-    async acquire(): Promise<MutexInterface.Releaser> {
-        const [, releaser] = await this._semaphore.acquire();
+    async acquire(data: U): Promise<MutexInterface.Releaser> {
+        const [, releaser] = await this._semaphore.acquire(data);
 
         return releaser;
     }
 
-    runExclusive<T>(callback: MutexInterface.Worker<T>): Promise<T> {
-        return this._semaphore.runExclusive(() => callback());
+    runExclusive<T>(callback: MutexInterface.Worker<T>, data: U): Promise<T> {
+        return this._semaphore.runExclusive(() => callback(), data);
     }
 
     isLocked(): boolean {
@@ -29,7 +29,7 @@ class Mutex implements MutexInterface {
         return this._semaphore.cancel();
     }
 
-    private _semaphore: Semaphore;
+    private _semaphore: Semaphore<U>;
 }
 
 export default Mutex;

--- a/src/MutexInterface.ts
+++ b/src/MutexInterface.ts
@@ -1,7 +1,7 @@
-interface MutexInterface {
-    acquire(): Promise<MutexInterface.Releaser>;
+interface MutexInterface<U = void> {
+    acquire(data: U): Promise<MutexInterface.Releaser>;
 
-    runExclusive<T>(callback: MutexInterface.Worker<T>): Promise<T>;
+    runExclusive<T>(callback: MutexInterface.Worker<T>, data: U): Promise<T>;
 
     isLocked(): boolean;
 

--- a/src/SemaphoreInterface.ts
+++ b/src/SemaphoreInterface.ts
@@ -1,7 +1,7 @@
-interface SemaphoreInterface {
-    acquire(): Promise<[number, SemaphoreInterface.Releaser]>;
+interface SemaphoreInterface<U = void> {
+    acquire(data: U): Promise<[number, SemaphoreInterface.Releaser]>;
 
-    runExclusive<T>(callback: SemaphoreInterface.Worker<T>): Promise<T>;
+    runExclusive<T>(callback: SemaphoreInterface.Worker<T>, data: U): Promise<T>;
 
     isLocked(): boolean;
 

--- a/test/semaphore-queue.ts
+++ b/test/semaphore-queue.ts
@@ -3,6 +3,9 @@ import TinyQueue from "tinyqueue";
 import { semaphoreSuite } from './semaphore';
 import { mutexSuite } from './mutex';
 import Mutex from '../src/Mutex';
+import assert from 'assert';
+import { InstalledClock, install } from '@sinonjs/fake-timers';
+import SemaphoreInterface from '../src/SemaphoreInterface';
 
 export default class HeapHelper<T> implements QueueLike<T> {
     constructor(private _queue: TinyQueue<T> = new TinyQueue()) {
@@ -35,6 +38,8 @@ export default class HeapHelper<T> implements QueueLike<T> {
             callbackfn(value, index, array);
         });
     }
+
+    toString = (): string => JSON.stringify(this._queue.data);
 }
 
 suite('Semaphore with Priority Queue', () => {
@@ -42,6 +47,51 @@ suite('Semaphore with Priority Queue', () => {
     semaphoreSuite((maxConcurrency: number, err?: Error) => new Semaphore(maxConcurrency, err, priorityQueue));
 
     // TODO: These tests validate the expected behavior of TinyQueue + Semaphore.
+    suite('TinyQueue Implementation Tests', () => {
+        let semaphore: SemaphoreInterface<number>;
+        let clock: InstalledClock;
+        const maxPriorityQueue = new TinyQueue<QueueEntry<number>>([], (a, b) => b.data - a.data);
+        const heap = new HeapHelper<QueueEntry<number>>(maxPriorityQueue);
+
+        setup(() => {
+            clock = install();
+            semaphore = new Semaphore(2, undefined, heap);
+        });
+
+        teardown(() => clock.uninstall());
+
+        test('Semaphore releases higher priority tasks first', async () => {
+
+            const [, release1] = await semaphore.acquire(0);
+            const [,] = await semaphore.acquire(2);
+            let prio5Finished = false;
+            let prio1Finished = false;
+            let prio10Finished = false;
+
+            (async () => {
+                await semaphore.acquire(5);
+                prio5Finished = true;
+            })();
+
+            (async () => {
+                await semaphore.acquire(1);
+                prio1Finished = true;
+            })();
+
+            (async () => {
+                await semaphore.acquire(10);
+                prio10Finished = true;
+            })();
+
+            release1();
+            await clock.tickAsync(1);
+
+            assert(prio5Finished === false, 'Priority 5 finished before Priority 10 AND Priority 1.');
+            assert(prio1Finished === false, 'Priority 1 finished before Priority 10.');
+            //@ts-expect-error Typescript doesn't know if a promise will run before this.
+            assert(prio10Finished === true, 'Priority 10 was not completed after semaphore was released.');
+        });
+    })
 });
 
 

--- a/test/semaphore-queue.ts
+++ b/test/semaphore-queue.ts
@@ -46,7 +46,7 @@ suite('Semaphore with Priority Queue', () => {
     const priorityQueue = new HeapHelper<QueueEntry>();
     semaphoreSuite((maxConcurrency: number, err?: Error) => new Semaphore(maxConcurrency, err, priorityQueue));
 
-    // TODO: These tests validate the expected behavior of TinyQueue + Semaphore.
+    // These tests validate the expected behavior of TinyQueue + Semaphore.
     suite('TinyQueue Implementation Tests', () => {
         let semaphore: SemaphoreInterface<number>;
         let clock: InstalledClock;
@@ -94,11 +94,16 @@ suite('Semaphore with Priority Queue', () => {
     })
 });
 
-
 suite('Mutex with Priority Queue', () => {
     const priorityQueue = new HeapHelper<QueueEntry>();
     mutexSuite((err?: Error) => new Mutex(err, priorityQueue));
 
     // TODO: These tests validate the expected behavior of TinyQueue + Mutex.
+});
+
+suite('withTimeout with Priority Queue', () => {
+    // const priorityQueue = new HeapHelper<QueueEntry>();
+
+    // TODO: These tests validate the expected behavior of TinyQueue + withTimeout.
 });
 


### PR DESCRIPTION
This changed from never to void because void is the absense of an
argument. This makes type guarantees a little cleaner.

test: Added a test for TinyQueue's implementation to verify that custom
queue logic holds up.